### PR TITLE
Fix path in link to setup page

### DIFF
--- a/_episodes/l1-02-committing-history.md
+++ b/_episodes/l1-02-committing-history.md
@@ -30,12 +30,14 @@ keypoints:
 
 ## First Things First
 
-You should have already completed the [setup instructions][lesson-setup] for this
-workshop and have Git installed. Launch a command line environment (on Windows
-launch "Git Bash" from the Start menu; on Linux or macOS start a new Terminal). We
-will use this command line interface throughout these materials. We focus on
-teaching Git with the command line as we believe this is the most thorough and
-portable way to communicate the underlying concepts.
+You should have already completed the
+<!-- markdownlint-disable -->
+[setup instructions][lesson-setup]
+<!-- markdownlint-restore --> for this workshop and have Git installed. Launch a command
+line environment (on Windows launch "Git Bash" from the Start menu; on Linux or macOS
+start a new Terminal). We will use this command line interface throughout these
+materials. We focus on teaching Git with the command line as we believe this is the most
+thorough and portable way to communicate the underlying concepts.
 
 You can use the command line to interact with Git but there is still some extra
 information you must provide before it is ready to use. Enter the following commands,

--- a/_episodes/l1-02-committing-history.md
+++ b/_episodes/l1-02-committing-history.md
@@ -53,7 +53,7 @@ what changes. The `--global` part of the command sets this information for
 any projects on which you might work on this computer. Therefore you only need
 to perform the above commands once for each new computer Git is installed on.
 
-[setup instructions]: {% link setup.md %}
+[setup instructions]: {{ page.root }}{% link setup.md %}
 
 > ## The Command Line Interface
 >

--- a/_episodes/l1-02-committing-history.md
+++ b/_episodes/l1-02-committing-history.md
@@ -30,7 +30,7 @@ keypoints:
 
 ## First Things First
 
-You should have already completed the [setup instructions] for this
+You should have already completed the [setup instructions][lesson-setup] for this
 workshop and have Git installed. Launch a command line environment (on Windows
 launch "Git Bash" from the Start menu; on Linux or macOS start a new Terminal). We
 will use this command line interface throughout these materials. We focus on
@@ -52,8 +52,6 @@ with Git. In collaborative projects this is used to distinguish who has made
 what changes. The `--global` part of the command sets this information for
 any projects on which you might work on this computer. Therefore you only need
 to perform the above commands once for each new computer Git is installed on.
-
-[setup instructions]: {{ page.root }}{% link setup.md %}
 
 > ## The Command Line Interface
 >


### PR DESCRIPTION
Fixes link to setup instructions from within an episode.

Note: the link is only broken in the gh-pages build (in the first proper paragraph [here](https://imperialcollegelondon.github.io/introductory_grad_school_git_course/l1-02-committing-history/index.html)) - it works when I build locally. I copied the Carpentries' lesson example [here](https://github.com/carpentries/lesson-example/blob/main/_episodes/07-checking.md), but if anyone is a jekyll/carpentries infrastructure expert then that would be great.

Closes #77 