### PR TITLE
Removed Git jargon meme

### DIFF
--- a/_episodes/l1-01-why-use-vcs.md
+++ b/_episodes/l1-01-why-use-vcs.md
@@ -131,8 +131,6 @@ its use are often only apparent in the longer term. Today we will make every
 effort to demystify Git and make clear why its usage is an essential part of
 any programming activity.
 
-<center><blockquote class="twitter-tweet"><p lang="en" dir="ltr">&quot;It&#39;s called a merge commit, Marty! It&#39;s a directed acyclic graph! We need to bisect and revert, and then use interactive rebasing possibly with a cherry-pick. What aren&#39;t you getting about this!?&quot; <a href="https://t.co/zahjHhiB33">pic.twitter.com/zahjHhiB33</a></p>&mdash; Gabriel Lebec (@g_lebec) <a href="https://twitter.com/g_lebec/status/1312115110685540352?ref_src=twsrc%5Etfw">October 2, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></center>
-
 These materials are written in the style of [The Carpentries][carpentries]. If
 attending an instance of this workshop you are fully encouraged to "type along"
 with the instructor in order to be able to complete the exercises.


### PR DESCRIPTION
This PR removes the Back to the Future image and joke about Git's jargon. The original Twitter post is no longer available, and the preceding paragraph makes the point that Git has a lot of jargon that we aim to demystify anyway, so I think we should just remove the link to this image and the caption.

Closes #81 