### PR TITLE
Use tabbed installation instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -17,7 +17,7 @@ do not extract it yet**.
 
 Please follow the relevant instructions depending on your operating system.
 
-::: tab
+::::::::::::::::::::::::::: tab
 
 ### Windows
 
@@ -109,7 +109,7 @@ output similar to the below:
 git version 2.40.0
 ```
 
-:::
+:::::::::::::::::::::::::::::::::::::
 
 ## Optional additional setup
 


### PR DESCRIPTION
This PR displays the per-OS install instructions as tabs, rather than as collapsible sections.

The nested bullets in the Windows instructions were causing some problems, so I've tidied that up a bit.

Closes #98 