### PR TITLE
Update code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,42 @@
 ---
-title: "Contributor Code of Conduct"
+title: "Code of Conduct"
 ---
 
-As contributors and maintainers of this project,
-we pledge to follow the [The Carpentries Code of Conduct][coc].
+Whether participating in this course, or in developing the course materials, we
+encourage the following kinds of behaviours:
 
-Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by following our [reporting guidelines][coc-reporting].
+- Use welcoming and inclusive language
+- Be respectful of different viewpoints and experiences
+- Gracefully accept constructive criticism
+- Focus on what is best for the course
+- Show courtesy and respect towards other course participants or developers
 
-[coc-reporting]: https://docs.carpentries.org/policies/coc/incident-reporting.html
+Examples of unacceptable behaviour by course participants or developers include:
+
+- Written or verbal comments which have the effect of excluding people on the basis of
+membership of any specific group
+- Causing someone to fear for their safety, such as through stalking, following, or
+intimidation
+- Violent threats or language directed against another person
+- The display of sexual or violent images
+- Unwelcome sexual attention
+- Nonconsensual or unwelcome physical contact
+- Sustained disruption of talks, events or communications
+- Insults or put downs
+- Sexist, racist, homophobic, transphobic, ableist, or exclusionary jokes
+- Excessive swearing
+- Incitement to violence, suicide, or self-harm
+- Continuing to initiate interaction (including photography or recording) with someone
+  after being asked to stop
+- Publication of private communication without consent
+
+Any form of behaviour to exclude, intimidate, or cause discomfort is a violation of the
+Code of Conduct.
+
+If you believe someone is violating the Code of Conduct, we ask that you report it to
+the [Research Software Engineering team](mailto:ict-rse-team@imperial.ac.uk), who will
+take the appropriate action to address the situation.
+
+This code of conducted has been adapted from [The Carpentries Code of Conduct][coc].
+
 [coc]: https://docs.carpentries.org/policies/coc/


### PR DESCRIPTION
This PR updates the code of conduct for the course. I have tried to make it applicable to both participants of the course and to developers of the materials (obviously the developers are, for the most part, us, but that need not be the case, since it is a public repo so anyone is welcome to contribute). 

It is heavily adapted from the [Carpentries CoC](https://docs.carpentries.org/policies/coc/), but tailored slightly for our purposes. I've simply copied their examples of expected and unacceptable behaviour (the latter of which get quite dark but I guess that's the point - we should be explicitly stating those behaviours are not tolerated).

Closes #93 