### PR TITLE
Change references to 'intermediate course' to 'further course'

### DIFF
--- a/episodes/01-course_overview.md
+++ b/episodes/01-course_overview.md
@@ -27,12 +27,12 @@ Beyond working on your own code, understanding Git allows usage of online code
 repositories such as GitHub. Using an online repository to publish your code is a great
 way to disseminate your research and a necessary step to collaborate with others. This
 course will demonstrate how to publish code to GitHub and introduce some of its basic
-features and functionality, while the [Intermediate course][intermediate-course]
+features and functionality, while the [further git & GitHub course][further-course]
 introduces more features that make it a productive collaborative environment.
 
 This course (particularly the first half) is closely based on this [Code Refinery lesson][code-refinery].
 
-[intermediate-course]: https://imperialcollegelondon.github.io/rse_further_git_course/
+[further-course]: https://imperialcollegelondon.github.io/rse_further_git_course/
 [code-refinery]: https://coderefinery.github.io/git-intro/
 
 ## Syllabus

--- a/episodes/03-committing_history.md
+++ b/episodes/03-committing_history.md
@@ -187,7 +187,7 @@ Ultimately, you can simply create a separate branch called `main` and use that o
 your default branch rather than `master`, which you can then delete.
 
 We will use `main` as the default branch name throughout the workshop. Branches will
-be covered in detail in [our intermediate Git course](https://imperialcollegelondon.github.io/rse_further_git_course/).
+be covered in detail in [our further Git course](https://imperialcollegelondon.github.io/rse_further_git_course/).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/06-remote_repositories.md
+++ b/episodes/06-remote_repositories.md
@@ -180,8 +180,7 @@ merge both. This merging might be a smooth, transparent process - Git is pretty 
 when it comes to merging branches - but might also result in **conflicts** that need
 to be resolved before proceeding.
 
-This is part of the scope of the intermediate Git and GitHub course that you can find
-in <https://imperialcollegelondon.github.io/rse_further_git_course/>
+This is part of the scope of the [further Git and GitHub course](https://imperialcollegelondon.github.io/rse_further_git_course/).
 
 ::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/09-guis_ides.md
+++ b/episodes/09-guis_ides.md
@@ -66,11 +66,10 @@ You wouldn't want to try to visualise this in your terminal, any more than you w
 Tube map.
 
 (If you're wondering how a repository's history can end up looking so complicated, it's
-because of a feature we aren't covering in this course in detail called branching. For
-those who are interested, [it is covered in the intermediate-level Git
-course][intermediate-branching].)
+because of a feature we aren't covering in this course in detail called *branching*. For
+those who are interested, [it is covered in the further Git course][further-branching].)
 
-[intermediate-branching]: https://imperialcollegelondon.github.io/rse_further_git_course/02-branching_merging/index.html
+[further-branching]: https://imperialcollegelondon.github.io/rse_further_git_course/02-branching_merging/index.html
 
 ## Getting started with GitKraken
 
@@ -122,7 +121,7 @@ most of the features in this window, namely:
   author, which files were changed etc.)
 
 (Don't worry about the other buttons on the left-hand side for now. They aren't covered
-in this course, but are in [the intermediate-level Git course][intermediate-course].)
+in this course, but are in [the further Git course][further-course].)
 
 Now click on "instructions.md" in GitKraken (under where it says "1 modified"). You
 should now be able to see what changes were made to the file in the the last commit:
@@ -146,7 +145,7 @@ remind yourself what changes you made.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-[intermediate-course]: https://imperialcollegelondon.github.io/rse_further_git_course/
+[further-course]: https://imperialcollegelondon.github.io/rse_further_git_course/
 
 ## Modifying your repository
 

--- a/handouts/common.tex
+++ b/handouts/common.tex
@@ -39,6 +39,6 @@ can find out more at the RSE team website (http://bit.ly/2SFropB) and the
 Imperial RSE Community website (http://bit.ly/2Hynf0q). You can also consult the
 expertise of the RSE team at the weekly RCS clinic (http://bit.ly/2SENqbU).
 
-You may also be interested in attending the course \textbf{``Intermediate Git and GitHub for Effective Collaboration''}, or in attending another course developed by the RSE team
+You may also be interested in attending the course \textbf{``Further Git and GitHub for Effective Collaboration''}, or in attending another course developed by the RSE team
 titled \textbf{``Essential Software Engineering for Researchers''} bookable via the Graduate School (http://bit.ly/2SHIwuI).
 }


### PR DESCRIPTION
There were a bunch of references to an 'intermediate' course, meaning the 'further' course (since 'intermediate' is misleading), so I've changed them.